### PR TITLE
Using leading dot syntax for every switch case

### DIFF
--- a/Source/GrandSugarDispatch.swift
+++ b/Source/GrandSugarDispatch.swift
@@ -41,17 +41,17 @@ public enum DispatchQueue {
 
     var dispatchQueue: dispatch_queue_t {
         switch self {
-        case main:
+        case .main:
             return dispatch_get_main_queue()
-        case userInteractive:
+        case .userInteractive:
             return dispatch_get_global_queue(QOS_CLASS_USER_INTERACTIVE, 0)
-        case userInitiated:
+        case .userInitiated:
             return dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0)
-        case regular:
+        case .regular:
             return dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0)
-        case utility:
+        case .utility:
             return dispatch_get_global_queue(QOS_CLASS_UTILITY, 0)
-        case background:
+        case .background:
             return dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0)
         case .concurrent(let name):
             return dispatch_queue_create(name, DISPATCH_QUEUE_CONCURRENT)
@@ -73,7 +73,7 @@ public func dispatch(queue queue: DispatchQueue, concurrency: Concurrency = .asy
         dispatch_barrier_async(queue.dispatchQueue, closure)
     case .barrierSync:
         dispatch_barrier_sync(queue.dispatchQueue, closure)
-    case .delay(let d):
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(d * Double(NSEC_PER_SEC))), queue.dispatchQueue, closure)
+    case .delay(let delay):
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(delay * Double(NSEC_PER_SEC))), queue.dispatchQueue, closure)
     }
 }


### PR DESCRIPTION
## Pull request checklist
- [ ] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/HowToContribute).
#### This fixes issue #___.
## What's in this pull request?

This PR adds leading dots to all cases in the `switch` statement for `dispatchQueue`.
Also removed an abbreviation (and now use it's full name) because why not?
